### PR TITLE
~ use ContentProvider to support sharing log file on Android API >= 24

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,17 @@ The lib uses native java logging and is <b>very small</b>.
 Usage
 -----
 
+Add the content provider to your application manifest
+
+<pre>
+&lt;provider
+	android:name="at.pansy.android.logging.helper.LogFileProvider"
+	android:authorities="${applicationId}.logfileprovider"
+	android:enabled="true"
+	android:exported="false"
+	android:grantUriPermissions="true" /&gt;
+</pre>
+
 Initialize logging in your application class
 
 <pre>

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.2'
+        classpath 'com.android.tools.build:gradle:2.3.2'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.2'
+        classpath 'com.android.tools.build:gradle:2.3.0'
     }
 }
 

--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -1,14 +1,14 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.2"
+    compileSdkVersion 25
+    buildToolsVersion "25.0.2"
 
     defaultConfig {
-        minSdkVersion 8
-        targetSdkVersion 23
+        minSdkVersion 9
+        targetSdkVersion 25
         versionCode 1
-        versionName "1.2"
+        versionName "1.3"
     }
     buildTypes {
         release {
@@ -20,6 +20,6 @@ android {
 
 dependencies {
     compile project(':lib')
-    compile 'com.android.support:appcompat-v7:23.+'
+    compile 'com.android.support:appcompat-v7:25.+'
     compile fileTree(dir: 'libs', include: ['*.jar'])
 }

--- a/demo/src/main/AndroidManifest.xml
+++ b/demo/src/main/AndroidManifest.xml
@@ -2,8 +2,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="at.pansy.android.logging.helper.demo" >
 
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-
     <application
         android:name=".DemoApplication"
         android:allowBackup="true"
@@ -18,6 +16,13 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <provider
+            android:name="at.pansy.android.logging.helper.LogFileProvider"
+            android:authorities="${applicationId}.logfileprovider"
+            android:enabled="true"
+            android:exported="false"
+            android:grantUriPermissions="true" />
     </application>
 
 </manifest>

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -3,14 +3,14 @@ apply plugin: 'maven'
 
 group = 'at.pansy.android'
 archivesBaseName = 'android-logging-helper'
-version = '1.2.1'
+version = '1.3.0'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.2"
+    compileSdkVersion 25
+    buildToolsVersion "25.0.2"
 
     defaultConfig {
-        minSdkVersion 8
+        minSdkVersion 9
         targetSdkVersion 23
         versionCode 1
         versionName version

--- a/lib/src/main/java/at/pansy/android/logging/helper/LogFileProvider.java
+++ b/lib/src/main/java/at/pansy/android/logging/helper/LogFileProvider.java
@@ -1,0 +1,153 @@
+package at.pansy.android.logging.helper;
+
+import android.content.ContentProvider;
+import android.content.ContentValues;
+import android.content.Context;
+import android.database.Cursor;
+import android.database.MatrixCursor;
+import android.net.Uri;
+import android.os.ParcelFileDescriptor;
+import android.provider.MediaStore;
+import android.provider.OpenableColumns;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class LogFileProvider extends ContentProvider {
+
+    private static final Logger logger = Logger.getLogger(LogFileProvider.class.getName());
+
+    /* package */ static final String EXPECTED_URI_PATH = "/logfile/";
+
+    /* package */ static final String DESTINATION_FILENAME = "logfile.log.gz";
+
+    private static final String[] COLUMNS = {
+            OpenableColumns.DISPLAY_NAME,
+            OpenableColumns.SIZE,
+    };
+
+    public LogFileProvider() {
+    }
+
+    public static Uri createFileUri(Context context, String tag) {
+        return new Uri.Builder()
+                .scheme("content")
+                .authority(context.getPackageName() + ".logfileprovider")
+                .path(EXPECTED_URI_PATH + tag)
+                .build();
+    }
+
+    public static File getDestinationFile(Context context) {
+        return new File(context.getCacheDir(), DESTINATION_FILENAME);
+    }
+
+    @Override
+    public boolean onCreate() {
+        return true;
+    }
+
+    private boolean isValidPath(Uri uri) {
+        return uri.getEncodedPath() != null && uri.getEncodedPath().startsWith(EXPECTED_URI_PATH);
+    }
+
+    @Override
+    public String getType(Uri uri) {
+        if (isValidPath(uri)) {
+            return "application/x-gzip";
+        }
+
+        return null;
+    }
+
+    @Override
+    public Cursor query(Uri uri, String[] projection, String selection, String[] selectionArgs, String sortOrder) {
+        if (!isValidPath(uri)) {
+            throw new UnsupportedOperationException("file is unavailable");
+        }
+
+        String tag = "logfile";
+        List<String> segments = uri.getPathSegments();
+        if (segments.size() >= 2) {
+            tag = segments.get(1);
+        }
+
+        if (projection == null) {
+            projection = COLUMNS;
+        }
+
+        String[] columns = new String[projection.length];
+        Object[] values = new Object[projection.length];
+        int i = 0;
+
+        for (String column : projection) {
+            Object value = null;
+
+            if (OpenableColumns.DISPLAY_NAME.equals(column)) {
+                value = tag + ".log.gz";
+            } else if (OpenableColumns.SIZE.equals(column)) {
+                try {
+                    File file = getDestinationFile(getContext());
+                    value = file.length();
+                } catch (Exception e) {
+                    logger.log(Level.SEVERE, "failed to read file length", e);
+                    value = 0;
+                }
+            }
+            // support for obscure apps, see: https://github.com/commonsguy/cwac-provider#supporting-legacy-apps
+            else if (MediaStore.MediaColumns.MIME_TYPE.equals(column)) {
+                value = getType(uri);
+            } else if (MediaStore.MediaColumns.DATA.equals(column)) {
+                value = uri.toString();
+            }
+
+            if (value != null) {
+                columns[i] = column;
+                values[i] = value;
+            }
+
+            i++;
+        }
+
+        columns = Arrays.copyOf(columns, i);
+        values = Arrays.copyOf(values, i);
+
+        MatrixCursor cursor = new MatrixCursor(columns, 1);
+        cursor.addRow(values);
+
+        return cursor;
+    }
+
+    @Override
+    public ParcelFileDescriptor openFile(Uri uri, String mode) throws FileNotFoundException {
+        if (!isValidPath(uri)) {
+            throw new UnsupportedOperationException("file is unavailable");
+        }
+
+        File file = getDestinationFile(getContext());
+        if (!file.exists()) {
+            throw new FileNotFoundException();
+        }
+
+        return ParcelFileDescriptor.open(file, ParcelFileDescriptor.MODE_READ_ONLY);
+    }
+
+    @Override
+    public Uri insert(Uri uri, ContentValues values) {
+        throw new UnsupportedOperationException("content provider is read-only");
+    }
+
+    @Override
+    public int delete(Uri uri, String selection, String[] selectionArgs) {
+        throw new UnsupportedOperationException("content provider is read-only");
+    }
+
+    @Override
+    public int update(Uri uri, ContentValues values, String selection,
+                      String[] selectionArgs) {
+        throw new UnsupportedOperationException("content provider is read-only");
+    }
+}


### PR DESCRIPTION
Use a `ContentProvider` to share the log file to other apps.

See: https://commonsware.com/blog/2016/03/14/psa-file-scheme-ban-n-developer-preview.html